### PR TITLE
CASMHMS-5037 Modify build to generate stable artifacts from release branches csm-1.0

### DIFF
--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -13,7 +13,7 @@ pipeline {
     environment {
         NAME = "hms-test"
         DESCRIPTION = "HMS test"
-        IS_STABLE = getBuildIsStable()
+        IS_STABLE = getBuildIsStable(releaseBranchIsStable: true)
         BUILD_METADATA = getRpmRevision(isStable: env.IS_STABLE)
     }
 


### PR DESCRIPTION
### Summary and Scope

This change sets the releaseBranchIsStable variable to true so that builds on hms-test release branches generate stable RPMs.

### Issues and Related PRs

* Resolves CASMHMS-5037 in csm-1.0.

### Testing

This change was tested by replaying an hms-test build in Jenkins on a release branch with the change in place and confirming that the resulting RPM was published to the stable repository rather than the unstable repository. It was also tested by building a feature branch with the change in place and confirming that the resulting RPM continued to be published to the unstable repository since it was not built from a release branch.

### Risks and Mitigations

Low-risk build change.